### PR TITLE
fix: Resolve terraform plan validation issues

### DIFF
--- a/terraform/environments/dev/variables.tf
+++ b/terraform/environments/dev/variables.tf
@@ -76,7 +76,7 @@ variable "db_storage_type" {
 variable "db_name" {
   description = "Database name"
   type        = string
-  default     = "nurlan-yagublu_dev"
+  default     = "nurlan_yagublu_dev"
 }
 
 variable "db_username" {

--- a/terraform/modules/security/main.tf
+++ b/terraform/modules/security/main.tf
@@ -296,6 +296,8 @@ resource "aws_iam_policy" "cicd_policy" {
           "ecs:DescribeServices",
           "ecs:DescribeTaskDefinition",
           "ecs:RegisterTaskDefinition"
+          ,
+          "ec2:DescribeAvailabilityZones"
         ]
         Resource = "*"
       },


### PR DESCRIPTION
- Fix database name validation by replacing hyphens with underscores
- Add ec2:DescribeAvailabilityZones permission for VPC networking
- This permission is required for ECS Fargate VPC subnet discovery

Note: EC2 permissions are needed for VPC operations even in serverless architectures