### PR TITLE
fix: Mark db_instance_endpoint output as sensitive

### DIFF
--- a/terraform/environments/dev/outputs.tf
+++ b/terraform/environments/dev/outputs.tf
@@ -18,6 +18,7 @@ output "private_app_subnet_ids" {
 output "db_instance_endpoint" {
   description = "RDS instance endpoint"
   value       = module.database.db_instance_endpoint
+  sensitive   = true
 }
 
 output "db_instance_id" {


### PR DESCRIPTION
- Add sensitive = true to db_instance_endpoint in environment outputs
- This matches the sensitive marking in the database module
- Resolves Terraform error about sensitive values in outputs

The database module correctly marks the endpoint as sensitive, but the environment-level output was exposing it without the sensitive flag.