### PR TITLE
fix: change npm ci to npm install in frontend deploy

### DIFF
--- a/.github/workflows/frontend-deploy.yml
+++ b/.github/workflows/frontend-deploy.yml
@@ -84,7 +84,7 @@ jobs:
           cd vue3-realworld-example-app
           
           echo "📦 Installing npm dependencies..."
-          npm ci
+          npm install --legacy-peer-deps
           
           echo "✅ Dependencies installed successfully!"
           


### PR DESCRIPTION
- Frontend deploy was still using npm ci which requires package-lock.json
- Changed to npm install --legacy-peer-deps to handle missing lock file
- This should resolve the frontend deployment npm error